### PR TITLE
A greater-than sign is required.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ $ t2b <filename> here
 $ t2b # Read directly from stdin
 ```
 
-`t2b` always writes to stdout. To output to a file, simply use a pipe (`|`).
+`t2b` always writes to stdout. To output to a file, simply use a greater-than sign (`>`).
 
 ## Language
 Newlines are solely for the sake of readability; all whitespace is the same.


### PR DESCRIPTION
The pipe symbol pipes through another executable.  A greater-than sign is required to redirect into a file.