### PR TITLE
Properly handle EOF

### DIFF
--- a/main.cc
+++ b/main.cc
@@ -173,7 +173,7 @@ int exec(std::istream &stream, std::ostream &out, string_map &variables, macro_m
     while (!stream.eof()) {
         stream >> command;
 
-        if (command.empty() || stream.eof()) continue;
+        if (stream.fail()) continue;
 
         HANDLE_NUM(command, "i8", stream, int8_t, 8, hexMode);
         HANDLE_NUM(command, "i16", stream, int16_t, 16, hexMode);


### PR DESCRIPTION
Two commits ago, the presence of a final newline caused duplicate execution of the last command.
One commit ago, the lack of a final newline cased the last command to be dropped.
This commit properly interprets the result of operator>>, and does 'the right thing'.

Fixes #10 for good.  Also see [the documentation of `operator>>`](http://www.cplusplus.com/reference/istream/istream/operator%3E%3E/#return), and note that `.fail()` checks both failbit and badbit.